### PR TITLE
Implement randomized rounding for coefficient initialization

### DIFF
--- a/R/risk_mod.R
+++ b/R/risk_mod.R
@@ -296,7 +296,7 @@ risk_mod <- function(X, y, gamma = NULL, beta = NULL, weights = NULL,
     # Round so betas within range
     gamma <- max(abs(coef_vals[-1]))/min(abs(a + 0.5), abs(b + 0.5))
     beta <- coef_vals/gamma
-    beta[-1] <- round(beta[-1])
+    beta <- randomized_rounding(beta)
   }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -195,3 +195,25 @@ get_metrics_internal <- function(mod, X = NULL, y = NULL, weights = NULL,
 
   return(list(dev = dev, acc=acc, sens=sens, spec=spec))
 }
+
+#' Randomly round the initialized coefficients before coordinate descent
+#'
+#' Round each LR coefficient based on its decimal value. The decimal is the probability
+#' of rounding the coefficient up to the next integer
+#' @param beta Numeric vector or  logistic regression coefficients initialized
+#' before cyclical coordinate descent in `risk_mod()`. The first element is the
+#' intercept and is not modified.
+#' @return A numeric vector with randomized rounding (apart from the first element).
+randomized_rounding <- function(beta) {
+
+  # Extract the decimals of the coefficients, excluding the intercept
+  beta_dec <- beta[-1] %% 1
+  # Binary rounding outcome
+  decision <- rbinom(n = length(beta_dec), size = 1, prob = beta_dec)
+
+  # Apply the randomized rounding for columns 2 to n
+  beta[-1] <- floor(beta[-1]) + decision
+
+  return(beta)
+}
+


### PR DESCRIPTION
### Changes Implemented
- Replace `round()` after logistic regression initialization in `risk_mod()` with `beta = NULL` to randomized rounding approach.
  - Randomized rounding uses the decimal values of each coefficient as the probability of rounding up to the next integer. For example, a value like `1.67` would have a `0.67` chance of being rounded up to `2`, and a `0.33` chance of being rounded down to `1`.
  - This change was mocked and tested with both the TB diagnosis and simulated data in various settings. All trials showed that randomized rounding initialization on average does better than the current standard rounding approach.