### PR TITLE
Add argument for running training in `risk_mod` multiple times

### DIFF
--- a/R/risk_mod.R
+++ b/R/risk_mod.R
@@ -326,8 +326,7 @@ risk_mod <- function(X, y, gamma = NULL, beta = NULL, weights = NULL,
     gamma <- res$gamma
     beta <- res$beta
 
-    return(list(gamma=gamma, beta=beta, X=X, y=y,
-                weights=weights, lambda0=lambda0))
+    return(list(gamma=gamma, beta=beta))
   }
 
   # Track minimum objective function and best model parameters
@@ -339,8 +338,7 @@ risk_mod <- function(X, y, gamma = NULL, beta = NULL, weights = NULL,
   for (i in 1:n_train_runs) {
     curr_mod <- run_risk_mod(X, y, gamma, beta, weights, lambda0, a, b,
                              max_iters, tol, shuffle)
-    curr_obj_fn <- obj_fcn(curr_mod$X, curr_mod$y, curr_mod$gamma,
-                           curr_mod$beta, curr_mod$weights, curr_mod$lambda0)
+    curr_obj_fn <- obj_fcn(X, y, curr_mod$gamma, curr_mod$beta, weights, lambda0)
 
     if (curr_obj_fn < min_obj_fn) {
       min_obj_fn <- curr_obj_fn

--- a/R/risk_mod.R
+++ b/R/risk_mod.R
@@ -209,8 +209,8 @@ risk_coord_desc <- function(X, y, gamma, beta, weights, lambda0 = 0,
 #'  observation. Unless otherwise specified, default will give equal weight to
 #'  each observation.
 #'  @param n_train_runs A positive integer representing the number of times to
-#'  train the model, returning the run with the highest accuracy for the
-#'  training data.
+#'  train the model, returning the run with the lowest objective function for
+#'  the training data.
 #' @param lambda0 Penalty coefficient for L0 term (default: 0).
 #'  See [cv_risk_mod()] for `lambda0` tuning.
 #' @param a Integer lower bound for coefficients (default: -10).
@@ -368,20 +368,19 @@ risk_mod <- function(X, y, gamma = NULL, beta = NULL, weights = NULL,
     return(mod)
   }
 
-  # Return the model with the highest accuracy after n_train_runs trains
-  highest_acc <- -Inf
-  highest_acc_mod <- NULL
+  # Return the model with the lowest objective function
+  min_obj_fn <- Inf
+  best_mod <- NULL
 
   for (i in 1:n_train_runs) {
-    mod <- run_risk_mod()
-    mod_pred_der <- predict(mod, type = "response")[,1]
-    mod_auc <- roc(y, mod_pred_der, quiet=TRUE) %>% auc()
+    curr_mod <- run_risk_mod()
+    curr_obj_fn <- obj_fcn(X, y, curr_mod$gamma, curr_mod$beta, weights, lambda0)
 
-    if (mod_auc > highest_acc) {
-      highest_acc <- mod_auc
-      highest_acc_mod <- mod
+    if (curr_obj_fn < min_obj_fn) {
+      min_obj_fn <- curr_obj_fn
+      best_mod <- curr_mod
     }
   }
 
-  return(highest_acc_mod)
+  return(best_mod)
 }

--- a/R/risk_mod.R
+++ b/R/risk_mod.R
@@ -313,8 +313,8 @@ risk_mod <- function(X, y, gamma = NULL, beta = NULL, weights = NULL,
   if (length(beta) != ncol(X)) stop("beta and X non-compatible")
   if (length(y) != nrow(X)) stop("y and X non-compatible")
 
-  if (!is.integer(n_times_run) | n_times_run < 0) {
-    stop("n_times_run must be a positive integer")
+  if (!is.integer(n_train_runs) | n_train_runs < 0) {
+    stop("n_train_runs must be a positive integer")
   }
 
   # Function to run coordinate descent
@@ -368,11 +368,11 @@ risk_mod <- function(X, y, gamma = NULL, beta = NULL, weights = NULL,
     return(mod)
   }
 
-  # Return the model with the highest accuracy after n_times_run trains
+  # Return the model with the highest accuracy after n_train_runs trains
   highest_acc <- -Inf
   highest_acc_mod <- NULL
 
-  for (i in 1:n_times_run) {
+  for (i in 1:n_train_runs) {
     mod <- run_risk_mod()
     mod_pred_der <- predict(mod, type = "response")[,1]
 

--- a/R/risk_mod.R
+++ b/R/risk_mod.R
@@ -313,7 +313,7 @@ risk_mod <- function(X, y, gamma = NULL, beta = NULL, weights = NULL,
   if (length(beta) != ncol(X)) stop("beta and X non-compatible")
   if (length(y) != nrow(X)) stop("y and X non-compatible")
 
-  if (!is.integer(n_train_runs) | n_train_runs < 0) {
+  if (n_train_runs != round(n_train_runs) | n_train_runs < 0) {
     stop("n_train_runs must be a positive integer")
   }
 

--- a/R/risk_mod.R
+++ b/R/risk_mod.R
@@ -374,7 +374,8 @@ risk_mod <- function(X, y, gamma = NULL, beta = NULL, weights = NULL,
 
   for (i in 1:n_train_runs) {
     curr_mod <- run_risk_mod()
-    curr_obj_fn <- obj_fcn(X, y, curr_mod$gamma, curr_mod$beta, weights, lambda0)
+    curr_obj_fn <- obj_fcn(curr_mod$X, curr_mod$y, curr_mod$gamma,
+                           curr_mod$beta, curr_mod$weights, curr_mod$lambda0)
 
     if (curr_obj_fn < min_obj_fn) {
       min_obj_fn <- curr_obj_fn

--- a/R/risk_mod.R
+++ b/R/risk_mod.R
@@ -375,9 +375,10 @@ risk_mod <- function(X, y, gamma = NULL, beta = NULL, weights = NULL,
   for (i in 1:n_train_runs) {
     mod <- run_risk_mod()
     mod_pred_der <- predict(mod, type = "response")[,1]
+    mod_auc <- roc(y, mod_pred_der, quiet=TRUE) %>% auc()
 
-    if (mod_pred_der > highest_acc) {
-      highest_acc <- mod_pred_der
+    if (mod_auc > highest_acc) {
+      highest_acc <- mod_auc
       highest_acc_mod <- mod
     }
   }


### PR DESCRIPTION
### Changes Implemented

- Add argument `n_train_runs` to `risk_mod` with default value 5 (ensures backwards compatibility)
- Add check for `n_train_runs` positive integer
- Refactor cyclical coordinate descent training to function`run_risk_mod` _within_ `risk_mod` (not exposed in the API)
  - `run_risk_mod` is called within a loop that has `n_train_runs` iterations
- Compare the accuracies of coefficients from training and return the model with the highest accuracy

### TODO

- [x] Correct accuracy calculation
- [x] Include initialization in each iteration (randomness)
- [x] Change AUC to objective function
- [x] Optimize loop by moving model score card to after `for` loop